### PR TITLE
Don't break inject

### DIFF
--- a/lib/soap/property.rb
+++ b/lib/soap/property.rb
@@ -317,17 +317,3 @@ end
 
 
 end
-
-
-# for ruby/1.6.
-unless(Enumerable.instance_methods.include?('inject') || RUBY_VERSION.to_s.start_with?('1.9'))
-  module Enumerable
-    def inject(init)
-      result = init
-      each do |item|
-	result = yield(result, item)
-      end
-      result
-    end
-  end
-end


### PR DESCRIPTION
Remove hack that adds support for 1.6 but kills other rubies. No one cares about 1.6 anymore.
