### PR TITLE
Add support for forcing SSL version for https enabled web services.

### DIFF
--- a/lib/soap/httpconfigloader.rb
+++ b/lib/soap/httpconfigloader.rb
@@ -108,6 +108,8 @@ module_function
         cfg.verify_callback = value
       when 'cert_store'
         cfg.cert_store = value
+      when 'ssl_version'
+        cfg.ssl_version = value.to_sym
       else
         raise ArgumentError.new("unknown ssl_config property #{key}")
       end


### PR DESCRIPTION
I added this feature to scratch an itch I had with one particular web service that broke after I upgraded OpenSSL on my system to 1.0.1.  This change allows for the SSL version (TLSv1, SSLv3 etc.) to be set via the http configuration loader.  By setting it to TSLv1 in my soap/property file I was able to fix the SSL negotiation with the server.  E.g:

[client.protocol.http]
ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
ssl_config.ssl_version = TLSv1
