### PR TITLE
Error: undefined method `collect' for #<String:0x007ff92c24c2c8> (NoMethodError) in Ruby 1.9.3

### DIFF
--- a/lib/xsd/codegen/gensupport.rb
+++ b/lib/xsd/codegen/gensupport.rb
@@ -244,7 +244,7 @@ private
   def trim_indent(str)
     indent = nil
     str = str.lines.collect { |line| untab(line) }.join
-    str.each do |line|
+    str.lines do |line|
       head = line.index(/\S/)
       if !head.nil? and (indent.nil? or head < indent)
         indent = head


### PR DESCRIPTION
Hopefully fixing: undefined method `collect' for #String:0x007ff92c24c2c8 (NoMethodError) in Ruby 1.9.3
