### PR TITLE
fixed: "NameError: uninitialized constant SOAP::HTTPStreamHandler::Versi...

### DIFF
--- a/lib/soap/version.rb
+++ b/lib/soap/version.rb
@@ -1,3 +1,3 @@
-module Soap
+module SOAP
   VERSION = Version = "1.5.9"
 end

--- a/soap2r.gemspec
+++ b/soap2r.gemspec
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "soap/version"
 
-Gem::Specification.new "soap2r", Soap::VERSION do |s|
+Gem::Specification.new "soap2r", SOAP::VERSION do |s|
   s.author = "NAKAMURA, Hiroshi"
   s.email = "nahi@ruby-lang.org"
   s.homepage = "https://github.com/felipec/soap4r"


### PR DESCRIPTION
...on" error

In 09981ab (extract version, 2013-12-26) SOAP::Version was replaced by
Soap::Version. But Ruby is case sensitive language and now reference to
SOAP::Version gives an error "NameError: uninitialized constant".

A simple method to reproduce the error is to run test_streamhandler test.
