### PR TITLE
Fixed bug with SourceFactory consuming first 3 chars

### DIFF
--- a/lib/xsd/xmlparser/rexmlparser.rb
+++ b/lib/xsd/xmlparser/rexmlparser.rb
@@ -21,6 +21,7 @@ class REXMLParser < XSD::XMLParser::Parser
   def do_parse(string_or_readable)
     source = nil
     source = REXML::SourceFactory.create_from(string_or_readable)
+    source.read if source.respond_to?(:read) #Becaise SourceFactory consumes first 3 chars
     source.encoding = charset if charset
     # Listener passes a String in utf-8.
     @charset = 'utf-8'


### PR DESCRIPTION
We have faced problem when working with SOAP source under ruby 2.1.1 resulted in losing first 3 chars of soap response. I turns out that REXML::SourceFactory reads first 3 bytes to define encoding and does not return it back. So we call read to force rewind on start.
