### PR TITLE
Depend on logger-application gem since it was removed from Ruby 2.2

### DIFF
--- a/bin/wsdl2ruby.rb
+++ b/bin/wsdl2ruby.rb
@@ -2,6 +2,9 @@
 
 require 'getoptlong'
 require 'logger'
+unless defined?(Logger::Application)
+  require 'logger-application'
+end
 require 'wsdl/soap/wsdl2ruby'
 
 

--- a/bin/xsd2ruby.rb
+++ b/bin/xsd2ruby.rb
@@ -2,6 +2,9 @@
 
 require 'getoptlong'
 require 'logger'
+unless defined?(Logger::Application)
+  require 'logger-application'
+end
 require 'wsdl/xmlSchema/xsd2ruby'
 
 

--- a/lib/soap/rpc/cgistub.rb
+++ b/lib/soap/rpc/cgistub.rb
@@ -10,6 +10,9 @@ require 'soap/streamHandler'
 require 'webrick/httpresponse'
 require 'webrick/httpstatus'
 require 'logger'
+unless defined?(Logger::Application)
+  require 'logger-application'
+end
 require 'soap/rpc/soaplet'
 
 
@@ -113,7 +116,7 @@ class CGIStub < Logger::Application
     @soaplet = ::SOAP::RPC::SOAPlet.new(@router)
     on_init
   end
-  
+
   def on_init
     # do extra initialization in a derived class if needed.
   end

--- a/lib/soap/rpc/httpserver.rb
+++ b/lib/soap/rpc/httpserver.rb
@@ -7,6 +7,9 @@
 
 
 require 'logger'
+unless defined?(Logger::Application)
+  require 'logger-application'
+end
 require 'soap/attrproxy'
 require 'soap/rpc/soaplet'
 require 'soap/streamHandler'
@@ -76,7 +79,7 @@ class HTTPServer < Logger::Application
   def add_rpc_servant(obj, namespace = @default_namespace)
     @router.add_rpc_servant(obj, namespace)
   end
-  
+
   def add_request_headerhandler(factory)
     @router.add_request_headerhandler(factory)
   end

--- a/soap2r.gemspec
+++ b/soap2r.gemspec
@@ -9,5 +9,6 @@ Gem::Specification.new "soap2r", SOAP::VERSION do |s|
   s.files = `git ls-files lib bin`.split("\n")
   s.executables = [ "wsdl2ruby.rb", "xsd2ruby.rb" ]
   s.add_dependency("httpclient", ">= 2.1.1")
+  s.add_dependency("logger-application", "~> 0.0.2")
   s.licenses = ["RUBY", "GPLv2"]
 end

--- a/test/interopR2/simonReg.rb
+++ b/test/interopR2/simonReg.rb
@@ -4,6 +4,9 @@ proxy = ARGV.shift || nil
 
 require 'soap/driver'
 require 'logger'
+unless defined?(Logger::Application)
+  require 'logger-application'
+end
 
 require 'iSimonReg'
 


### PR DESCRIPTION
The Logger::Application class was extracted from Ruby 2.2 and moved to the logger-application gem as it is no longer maintained:
https://bugs.ruby-lang.org/issues/9860

This requires the gem version when the Logger::Application constant is not defined.

Ideally, soap2r should be refactored to no longer depend on the Logger::Application class since it is no longer maintained.
